### PR TITLE
Load balancer patch 

### DIFF
--- a/roles/example-cnf-app/templates/testpmd-cr.yaml.j2
+++ b/roles/example-cnf-app/templates/testpmd-cr.yaml.j2
@@ -9,7 +9,11 @@ spec:
   org: "{{ repo_name }}"
   version: "{{ app_version }}"
   imagePullPolicy: {{ image_pull_policy }}
+{% if enable_lb|bool %}
   ethpeerMaclist: {{ lb_cnf_port_mac_list }}
+{% else %}
+  ethpeerMaclist: {{ trex_mac_list }}
+{% endif %}
   networks: {{ cnf_app_networks }}
   terminationGracePeriodSeconds: {{ termination_grace_period_seconds }}
 {% if mac_workaround_enable|default(true)|bool %}

--- a/roles/example-cnf-app/templates/trex-cr.yaml.j2
+++ b/roles/example-cnf-app/templates/trex-cr.yaml.j2
@@ -14,5 +14,6 @@ spec:
   version: {{ app_version }}
   imagePullPolicy: {{ image_pull_policy }}
   networks: {{ networks_trex }}
+  enableLb: {{ enable_lb }}
   lbMacs: {{ lb_gen_port_mac_list }}
   cpu: 6


### PR DESCRIPTION
Operator failed to pick the right destination MAC in certain cases while `enable_lb: false`, this patch should fix them