### PR TITLE
Patch for trex nework

### DIFF
--- a/roles/example-cnf-app/tasks/trex-app.yaml
+++ b/roles/example-cnf-app/tasks/trex-app.yaml
@@ -20,7 +20,7 @@
 - name: create network list for trex with hardcoded macs
   set_fact:
     networks_trex: "{{ networks_trex + [ item | combine({ 'mac': trex_mac_list[idx:idx+item.count] }) ] }}"
-  loop: "{{ packet_generator_networks }}"
+  loop: "{{ packet_generator_networks if enable_lb|bool else cnf_app_networks }}"
   loop_control:
     index_var: idx
 

--- a/roles/example-cnf-app/tasks/trex-app.yaml
+++ b/roles/example-cnf-app/tasks/trex-app.yaml
@@ -8,19 +8,19 @@
 - fail:
     msg: "One of the node should have Label (examplecnf.openshift.io/trex='')"
   when: "trex_node_count|int == 0"
-- name: set networks_trex fact as empty list
+- name: set local fact for trex pod networks
   set_fact:
     networks_trex: []
-
+    packet_gen_net: "{{ packet_generator_networks if enable_lb|bool else cnf_app_networks }}"
 # TODO(skramaja): This logic to be improved for multiple
 # networks, lets fail it if the length is > 1
 - fail:
     msg: "Need to rewrite the mac merging logic"
-  when: "packet_generator_networks|length != 1"
+  when: "packet_gen_net|length != 1"
 - name: create network list for trex with hardcoded macs
   set_fact:
     networks_trex: "{{ networks_trex + [ item | combine({ 'mac': trex_mac_list[idx:idx+item.count] }) ] }}"
-  loop: "{{ packet_generator_networks if enable_lb|bool else cnf_app_networks }}"
+  loop: "{{ packet_gen_net }}"
   loop_control:
     index_var: idx
 


### PR DESCRIPTION
During load balancer mode, users have to provide 2 networks - `cnf_app_networks` for testpmd pods and `packet_generator_networks` for trafficgen pods.
During direct mode, `cnf_app_networks` is used for both testpmd pods as well as trafficgen pods.