### PR TITLE
Reuse ocp version facts

### DIFF
--- a/roles/example-cnf-app/tasks/app.yaml
+++ b/roles/example-cnf-app/tasks/app.yaml
@@ -11,30 +11,19 @@
   poll: 2
   failed_when: "net_list|length == 0"
 
-- name: Get the clusterversion info
-  k8s_info:
-    kind: ClusterVersion
-  register: cluster_version
-- fail:
-    msg: "CluterVersion object version is not available"
-  when: "{{ cluster_version.resources[0].spec.channel|length == 0 }}"
-- name: Parse the major and minor version from channel
-  set_fact:
-    ocp_version: "{{ cluster_version.resources[0].spec.channel.split('-')[1] }}"
-    ocp_major: "{{ cluster_version.resources[0].spec.channel.split('-')[1].split('.')[0] }}"
-    ocp_minor: "{{ cluster_version.resources[0].spec.channel.split('-')[1].split('.')[1] }}"
 - name: Set mac workaround
   set_fact:
     mac_workaround_enable: true
   when:
-    - ocp_major|int == 4
-    - ocp_minor|int <= 5
+    - ocp_version_maj|int == 4
+    - ocp_version_min|int <= 5
 
 - name: get all nodes
   k8s_info:
     kind: Node
   register: nodes
   no_log: true
+
 - fail:
     msg: "Minimum 2 worker nodes are required to run example-cnf applications"
   when: "nodes.resources|length < 2"
@@ -44,10 +33,12 @@
   when:
     - "enable_lb|bool"
     - "packet_generator_networks|length == 0"
+
 - fail:
     msg: "'cnf_app_networks' is required"
   when:
     - "cnf_app_networks|length == 0"
+
 - fail:
     msg: "MAC merging is not supported with multiple networks"
   when: "cnf_app_networks|length > 1 or (enable_lb|bool and packet_generator_networks|length > 1)"
@@ -56,12 +47,14 @@
   set_fact:
     pack_nw: []
     cnf_nw: []
+
 - name: create packet gen network list for lb with hardcoded macs
   set_fact:
     pack_nw: "{{ pack_nw + [ item | combine({ 'mac': lb_gen_port_mac_list[idx:idx+item.count] }) ] }}"
   loop: "{{ packet_generator_networks }}"
   loop_control:
     index_var: idx
+
 - name: create cnf app network list for lb with hardcoded macs
   set_fact:
     cnf_nw: "{{ cnf_nw + [ item | combine({ 'mac': lb_cnf_port_mac_list[idx:idx+item.count] }) ] }}"
@@ -88,6 +81,7 @@
   delay: 5
   until:
     - testpmd_pods.resources|length >= 1
+
 - name: check testpmd pod status to be running
   k8s_info:
     namespace: "{{ cnf_namespace }}"
@@ -125,15 +119,18 @@
             state: absent
         - pause:
             seconds: 45
+
         - name: re-run trex tasks to create app again
           include_tasks: trex-app.yaml
       when:
         - "trex_retry|default(true)|bool"
         - "not trex_app_run_passed|default(false)|bool"
+
     - name: fail if trex is not passed
       fail:
         msg: "TRex App Run has failed!!"
       when: not trex_app_run_passed|default(false)|bool
+
     - name: trex additional tests
       include_tasks: trex-tests.yaml
       when: "trex_test_config|length > 0 and not continous_burst_mode|bool"


### PR DESCRIPTION
Some facts are already used in the [pre-run](https://github.com/dallas-telco-lab/example-cnf-config/blob/master/testpmd/hooks/pre-run.yml#L13-L15), we could reuse them to avoid doing calls to the clusterversion, which will not have cluster-admin permissions in the future