### PR TITLE
Remove cluster_repo_name from catalog_image

### DIFF
--- a/roles/example-cnf-catalog/defaults/main.yml
+++ b/roles/example-cnf-catalog/defaults/main.yml
@@ -6,8 +6,9 @@ registry_url: "jumphost.{{ cluster_name }}.dfwt5g.lab:5000"
 repo_name: nfv-example-cnf
 
 image_pull_policy: Always
+cluster_repo_name: "{{ repo_name }}"
 
 catalog_name: nfv-example-cnf-catalog
-catalog_image: "{{ registry_url }}/{{ repo_name }}/{{ catalog_name }}:{{ operator_version }}"
+catalog_image: "{{ registry_url }}/{{ cluster_repo_name }}/{{ catalog_name }}:{{ operator_version }}"
 
 cnf_namespace: example-cnf

--- a/roles/example-cnf-catalog/defaults/main.yml
+++ b/roles/example-cnf-catalog/defaults/main.yml
@@ -6,9 +6,8 @@ registry_url: "jumphost.{{ cluster_name }}.dfwt5g.lab:5000"
 repo_name: nfv-example-cnf
 
 image_pull_policy: Always
-cluster_repo_name: "{{ repo_name }}{% if cluster_name %}-{{ cluster_name }}{% endif %}"
 
 catalog_name: nfv-example-cnf-catalog
-catalog_image: "{{ registry_url }}/{{ cluster_repo_name }}/{{ catalog_name }}:{{ operator_version }}"
+catalog_image: "{{ registry_url }}/{{ repo_name }}/{{ catalog_name }}:{{ operator_version }}"
 
 cnf_namespace: example-cnf

--- a/roles/example-cnf-catalog/tasks/main.yml
+++ b/roles/example-cnf-catalog/tasks/main.yml
@@ -3,15 +3,17 @@
   fail:
     msg: "operator_version is required"
   when: "operator_version|length == 0"
+
 - name: check if catalogsource crd is present
   k8s_info:
     kind: CustomResourceDefinition
     name: catalogsources.operators.coreos.com
   register: crd_info
-- name: fail if catalogsource resource is not found
-  fail:
-    msg: "missing catalogsources.operators.coreos.com CRD"
-  when: crd_info.resources|length == 0
+  retries: 1
+  delay: 5
+  until: crd_info.resources|length != 0
+  failed_when: crd_info.resources|length == 0
+
 - name: create catalogsource object for example-cnf
   k8s:
     state: present
@@ -24,10 +26,11 @@
       spec:
         sourceType: grpc
         image: "{{ catalog_image }}"
-        displayName: NFV Example CNF CataloG
+        displayName: NFV Example CNF Catalog
         updateStrategy:
-          registryPoll: 
+          registryPoll:
             interval: 30m
+
 - name: wait for testpmd-operator packagemanifests creation
   k8s_info:
     api_version: packages.operators.coreos.com/v1
@@ -39,6 +42,7 @@
   delay: 5
   until: pkg_manifest_testpmd.resources|length != 0
   failed_when: pkg_manifest_testpmd.resources|length == 0
+
 - name: wait for trex-operator packagemanifests creation
   k8s_info:
     api_version: packages.operators.coreos.com/v1
@@ -50,11 +54,13 @@
   delay: 5
   until: pkg_manifest_trex.resources|length != 0
   failed_when: pkg_manifest_trex.resources|length == 0
+
 - name: create namespace
   k8s:
     api_version: v1
     name: "{{ cnf_namespace }}"
     kind: Namespace
+
 - name: create operatorgroup
   k8s:
     api_version: operators.coreos.com/v1


### PR DESCRIPTION
- Remove the use of cluster_repo_name in the catalog_image, this is to avoid going to different namespaces in a registry and to use the same image regardless of the cluster
- Formatting to catalog main task