### PR TITLE
Double testpmd manifest creation wait time

### DIFF
--- a/roles/example-cnf-catalog/tasks/main.yml
+++ b/roles/example-cnf-catalog/tasks/main.yml
@@ -51,7 +51,7 @@
     name: testpmd-operator
     namespace: default
   register: pkg_manifest_testpmd
-  retries: 30
+  retries: 60
   delay: 5
   until: pkg_manifest_testpmd.resources|length != 0
   failed_when: pkg_manifest_testpmd.resources|length == 0


### PR DESCRIPTION
Had timeout error for ocp-4.8 [three times in a row this morning](https://www.distributed-ci.io/jobs/d9111672-575a-4e30-a410-a8d491bddd9c/jobStates#2f5385a6-a4d4-49d4-b843-d0a46e67e0ce:file76).

According to direct logs from the cluster, manifest was not created. The idea is to double wait time.

```
$ oc version
Client Version: 4.8.21
Server Version: 4.8.21
Kubernetes Version: v1.21.5+6a39d04

$ oc get catalogsource -n openshift-marketplace
NAME                        DISPLAY                   TYPE   PUBLISHER   AGE
mirrored-redhat-operators   Red Hat Operators         grpc   grpc        13h
nfv-example-cnf-catalog     NFV Example CNF Catalog   grpc               39m

$ oc get packagemanifest -n openshift-marketplace
NAME                         CATALOG             AGE
sriov-network-operator       Red Hat Operators   13h
performance-addon-operator   Red Hat Operators   13h
kubevirt-hyperconverged      Red Hat Operators   13h
```
