### PR TITLE
[do not merge, for tests] Retrieve Trex TestFailed event

### DIFF
--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -72,6 +72,7 @@
     retries: 60
     delay: 5
     until: trex_event.resources|length > 0
+
   - name: get test passed event from trex
     k8s_info:
       namespace: "{{ cnf_namespace }}"
@@ -80,6 +81,16 @@
         - "reason==TestPassed"
         - "involvedObject.name={{ trex_app_cr_name }}"
     register: trex_result
+
+  - name: get test failed event from trex
+    k8s_info:
+      namespace: "{{ cnf_namespace }}"
+      kind: Event
+      field_selectors:
+        - "reason==TestFailed"
+        - "involvedObject.name={{ trex_app_cr_name }}"
+    register: trex_result_failed
+
   - name: get packet matched event from trex
     k8s_info:
       namespace: "{{ cnf_namespace }}"


### PR DESCRIPTION
This PR is to investigate why the Trex TestPassed event is present only on clusters 5 and 6 but never on cluster 4. 
Trex TestCompleted event is well present on all clusters. 