### PR TITLE
Ignore errors in error gather task if there is no pods running

### DIFF
--- a/roles/example-cnf-app/tasks/retry-trex.yaml
+++ b/roles/example-cnf-app/tasks/retry-trex.yaml
@@ -29,6 +29,7 @@
           - example-cnf-type=pkt-gen-app
           - job-name=job-{{ trex_app_cr_name }}
       register: trex_app_logs
+      ignore_errors: true
 
     - name: Store logs when jobs_logs is defined
       copy:
@@ -37,6 +38,8 @@
       when:
         - job_logs is defined
         - job_logs.path is defined
+        - trex_app_logs.stderr | length == 0
+      ignore_errors: true
 
     - name: delete trexconfig cr
       k8s:


### PR DESCRIPTION
If no TRex pods are running, we have an error to gather logs, that makes the job fail and prevent the execution of the subsequent tests, like in the job: https://www.distributed-ci.io/jobs/42a6812f-b64a-4e40-845d-43476f07e929/jobStates 
The idea of the current PR is to ignore errors during the log gathering.