### PR TITLE
Fix TRex logs gathering

### DIFF
--- a/roles/example-cnf-app/tasks/retry-trex.yaml
+++ b/roles/example-cnf-app/tasks/retry-trex.yaml
@@ -38,7 +38,7 @@
       when:
         - job_logs is defined
         - job_logs.path is defined
-        - trex_app_logs.stderr | length == 0
+        - not trex_app_logs.failed
       ignore_errors: true
 
     - name: delete trexconfig cr


### PR DESCRIPTION
This is the second fix.

The initial problem was to avoid the fail [when no TRex pods are running and hence `trex_app_logs` contains only `.failed` attribute](https://www.distributed-ci.io/jobs/42a6812f-b64a-4e40-845d-43476f07e929/jobStates#464f4ce8-2848-440b-87e6-b26e98df4efe:file52).
 
```
TASK [/var/lib/dci/example-cnf-config/testpmd/hooks/cluster6/nfv-example-cnf-deploy/roles/example-cnf-app : Retrieve TRex app logs]

fatal: [jumphost]: FAILED! => {"changed": false, "msg": "No pods in namespace example-cnf matched selector example-cnf-type=pkt-gen-app,job-name=job-trex-app1"}
```

[The first fix](https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/18) helped to remove the problem in the case of fail but [prevented log gathering if pods were running](https://www.distributed-ci.io/jobs/e12843a1-d907-4ecd-80b7-0d8a4315d983/jobStates#897df7fa-0620-4d4a-b1b7-0800f2883575:file58). 

```
"The conditional check 'trex_app_logs.stderr | length == 0' failed. The error was: error while evaluating conditional (trex_app_logs.stderr | length == 0): 'dict object' has no attribute 'stderr'
```

Here is the second simplified fix.