### PR TITLE
Delay for policy to be applied on the nodes after creating CR for loadbalancer

### DIFF
--- a/roles/example-cnf-app/tasks/lb-app.yaml
+++ b/roles/example-cnf-app/tasks/lb-app.yaml
@@ -3,6 +3,9 @@
   k8s:
     definition: "{{ lookup('template', 'lb-cr.yaml.j2') }}"
 
+- name: Wait for updated MC to be applied on the nodes and retrieve logs
+  include_tasks: mcp_wait_and_logs.yml
+
 - name: check loadbalacer pod count to be 1
   k8s_info:
     namespace: "{{ cnf_namespace }}"

--- a/roles/example-cnf-app/tasks/mcp_wait_and_logs.yml
+++ b/roles/example-cnf-app/tasks/mcp_wait_and_logs.yml
@@ -1,0 +1,48 @@
+---
+- name: Delay for policy to apply, there is no nodes to reboot anymore since ocp-4.7
+  pause:
+    minutes: 1
+
+- name: Wait for updated machine configs to be applied on the nodes
+  block:
+    - name: First wait
+      k8s_info:
+        api_version: machineconfiguration.openshift.io/v1
+        kind: MachineConfigPool
+      register: reg_mcpool_status
+      vars:
+        status_query: "resources[*].status.conditions[?type=='Updated'].status"
+        update_status: "{{ reg_mcpool_status | json_query(status_query) | flatten | unique }}"
+      until:
+        - update_status == ['True']
+      retries: 60
+      delay: 60
+  always:
+    - name: Then retrieve mcp logs
+      shell: |
+        echo "oc get mcp =========="
+        {{ oc_tool_path }} get mcp
+        echo "oc get mc =========="
+        {{ oc_tool_path }} get mc
+        echo "oc describe mcp worker =========="
+        {{ oc_tool_path }} describe mcp worker
+      register: mcp_logs
+
+    - name: Retrieve list of worker nodes
+      shell: >
+        {{ oc_tool_path }} get nodes --selector=node-role.kubernetes.io/worker -o custom-columns=NAME:.metadata.name --no-headers
+      register: worker_nodes
+
+    - name: Retrieve worker logs
+      shell: |
+        echo "oc describe node {{ item }} =========="
+        {{ oc_tool_path }} describe node {{ item }}
+      loop: "{{ worker_nodes.stdout.split('\n') }}"
+      register: mcp_worker_logs
+
+    - name: Upload logs into DCI
+      template:
+        src: "mcp_logs.j2"
+        dest: "{{ job_logs.path }}/cnf-example-deployment_loadbalancer_mcp_logs.log"
+
+...

--- a/roles/example-cnf-app/templates/mcp_logs.j2
+++ b/roles/example-cnf-app/templates/mcp_logs.j2
@@ -1,0 +1,4 @@
+Main logs:
+{{ mcp_logs.stdout }}
+Worker logs:
+{{ mcp_worker_logs | json_query('results[*].stdout') | join('\n') }}


### PR DESCRIPTION
The problem is that sometimes [loadbalancer pod doesn't start](https://www.distributed-ci.io/jobs/b9515543-cded-4935-9666-d211452c2c14/jobStates#bf2dd9d8-3988-47a0-8305-2d24e6a65886:file37).

The reason for the no-start is insufficient network
```
"message": "0/7 nodes are available: 1 node(s) were unschedulable, 3 Insufficient openshift.io/intel_numa0_res2, 3 node(s) had taint {node-role.kubernetes.io/master: }, that the pod didn't tolerate.", "reason": "Unschedulable"
```

If we check allocatable resources for each worker node, `intel_numa0_res2` is well absent, and sometimes even `intel_numa0_res1`. 

My theory is that maybe we wait not enough after the creation of loadbalancer CR. I'm adding several tasks here:
- Delay for policy to be applied on the nodes
- Ensure MCP status
- Retrieve the detailed logs for each worker, to check events, allocated resources, and rendered configs.

[Tested here](https://www.distributed-ci.io/jobs/1e949271-116a-4046-9e12-eaedde8b5f77/jobStates#7c33dcc6-b3b4-469a-943a-88d9ba8b1b80:file36) and [here are retrieved logs](https://www.distributed-ci.io/files/5a51c5c5-7735-4f78-b8e3-a23a212f5425).