### PR TITLE
Ensure loadbalancer pod and container status

### DIFF
--- a/roles/example-cnf-app/tasks/lb-app.yaml
+++ b/roles/example-cnf-app/tasks/lb-app.yaml
@@ -3,17 +3,6 @@
   k8s:
     definition: "{{ lookup('template', 'lb-cr.yaml.j2') }}"
 
-- name: check loadbalacer pod count to be 1
-  k8s_info:
-    namespace: "{{ cnf_namespace }}"
-    kind: Pod
-    label_selectors:
-      - example-cnf-type=lb-app
-  register: lb_pods
-  retries: 60
-  delay: 5
-  until:
-    - lb_pods.resources|length == 1
 - name: check loadbalancer pod status to be running
   k8s_info:
     namespace: "{{ cnf_namespace }}"
@@ -21,8 +10,12 @@
     label_selectors:
       - example-cnf-type=lb-app
   register: lb_pods
+  vars:
+    container_query: "resources[0].status.containerStatuses[?name=='loadbalancer'].state.running"
+    container_status: "{{ lb_pods | json_query(container_query) }}"
   retries: 60
   delay: 5
   until:
+    - lb_pods.resources | length == 1
     - lb_pods.resources[0].status.phase == 'Running'
-
+    - container_status | bool


### PR DESCRIPTION
Currently, we ensure the count and running status of loadbalancer pod. That's not enough in the case of `CrashLoopBackOff` error. We have to ensure that the container status is `running` as well.

Here is an example of [the job that passed two first tests: pod count = 1 and the pod is running but failed the container check](https://www.distributed-ci.io/jobs/63df2993-bccc-49f4-b6cb-27e550013304/jobStates#7760e92e-d7ff-40e5-82fd-b9c230474f2e:file36). 
Container status was 
```
[{'waiting': {'message': 'back-off 5m0s restarting 
failed container=loadbalancer 
pod=loadbalancer-748b5f498-gtn6d_example-cnf(74c6ff95-8e81-4751-ba09-48addc561f04)', 
'reason': 'CrashLoopBackOff'}}]
```