### PR TITLE
Fix condition for loadbalancer container

### DIFF
--- a/roles/example-cnf-app/tasks/lb-app.yaml
+++ b/roles/example-cnf-app/tasks/lb-app.yaml
@@ -18,4 +18,4 @@
   until:
     - lb_pods.resources | length == 1
     - lb_pods.resources[0].status.phase == 'Running'
-    - container_status | bool
+    - container_status | length > 0


### PR DESCRIPTION
This PR is to refine the fix introduced in #21 - to continue only when the container is running.

The previous fix worked fine to filter out "bad" containers with status=waiting.
Now we have a [fix](https://github.com/dci-labs/example-cnf-config/pull/46), container=running, but the condition is not passing.

```
# bad situation
container_status = []
container_status | bool = False 

# good situation
container_status = [{'startedAt': '2022-02-23T02:02:37Z'}]
container_status | bool = False  <---- we need it to be True
``` 

The idea is to change `container_status | bool` to `container_status | length > 0`

