### PR TITLE
Fix variable name for TRex result

### DIFF
--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -85,7 +85,7 @@
     register: trex_result
     retries: 5
     delay: 5
-    until: trex_results.resources | length > 0
+    until: trex_result.resources | length > 0
 
   - name: get packet matched event from trex
     k8s_info:


### PR DESCRIPTION
To fix the misprint introduced in the [previous PR](https://www.distributed-ci.io/jobs/96cd60ed-013e-4248-8573-120be68af833/jobStates#530a4f71-93ed-42e2-80e9-074cfa43f824:file185):
```
task path: /var/lib/dci/example-cnf-config/testpmd/hooks/cluster4/nfv-example-cnf-deploy/roles/example-cnf-app/tasks/trex/app.yaml:78
fatal: [jumphost]: FAILED! => {"msg": "The conditional check 'trex_results.resources | length > 0' failed. The error was: error while evaluating conditional (trex_results.resources | length > 0): 'trex_results' is undefined"}
```