### PR TITLE
Added additional check to the mac.resources retry condition

### DIFF
--- a/roles/example-cnf-app/tasks/app.yaml
+++ b/roles/example-cnf-app/tasks/app.yaml
@@ -122,6 +122,7 @@
   retries: 120
   delay: 5
   until:
+    - mac.resources is defined
     - mac.resources|length > 0
 
 - name: trex cr block


### PR DESCRIPTION
But seen in DCI job:
https://www.distributed-ci.io/jobs/9117415a-ed67-47c7-897f-763fc70f6fe4/jobStates

The until condition "mac.resources|length > 0" caused the task to crash if mac.resources is not defined.