### PR TITLE
Wait for TRex app CR, add security labels to namespace and use machine GA API to improve the stability

### DIFF
--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -1,105 +1,117 @@
 ---
-- name: set local fact for trex pod networks
+- name: Set local fact for trex pod networks
   set_fact:
     networks_trex: []
     packet_gen_net: "{{ packet_generator_networks if enable_lb|bool else cnf_app_networks }}"
     trex_app_run_passed: false
+
 # TODO(skramaja): This logic to be improved for multiple
 # networks, lets fail it if the length is > 1
 - fail:
     msg: "Need to rewrite the mac merging logic"
   when: "packet_gen_net|length != 1"
-- name: create network list for trex with hardcoded macs
+
+- name: Create network list for trex with hardcoded macs
   set_fact:
     networks_trex: "{{ networks_trex + [ item | combine({ 'mac': trex_mac_list[idx:idx+item.count] }) ] }}"
   loop: "{{ packet_gen_net }}"
   loop_control:
     index_var: idx
 
-- name: create cr for trex server
+- name: Create CR for trex server
   k8s:
     definition: "{{ lookup('template', 'trex-server-cr.yaml.j2') }}"
-- name: check trex pod status to be running
+
+- name: Check TRex pod status to be running
   k8s_info:
     namespace: "{{ cnf_namespace }}"
     kind: Pod
     label_selectors:
       - example-cnf-type=pkt-gen
   register: trex_result
+  until: trex_result | json_query('resources[*].status.phase') | unique == ["Running"]
   retries: 60
   delay: 5
-  until:
-    - "trex_result.resources|length > 0"
-    - "'status' in trex_result.resources[0]"
-    - "'phase' in trex_result.resources[0].status"
-    - "trex_result.resources[0].status.phase == 'Running'"
-- name: set trex run status if passed
+
+- name: Set TRex run status if the previous step passed
   set_fact:
     trex_app_run_passed: true
-  when: trex_result.resources|length > 0
+  when: trex_result.resources | length > 0
 
-- name: trexapp block
-  when: enable_trex_app|bool
+- name: TRexApp block
   block:
-  - name: set trex app cr name
-    set_fact:
-      duration: 120
-  - name: create cr for trex app
-    k8s:
-      definition: "{{ lookup('template', 'trex-app-cr.yaml.j2') }}"
-    vars:
-      packet_rate: 10kpps
-      packet_size: 64
+    - name: Set TRex app CR name
+      set_fact:
+        duration: 120
 
-  - name: wait for trex app run start event
-    k8s_info:
-      namespace: "{{ cnf_namespace }}"
-      kind: Event
-      field_selectors:
-        - "reason==TestStarted"
-        - "involvedObject.name={{ trex_app_cr_name }}"
-    register: trex_event
-    retries: 60
-    delay: 5
-    until: trex_event.resources | length > 0
+    - name: Create CR for TRex app
+      k8s:
+        definition: "{{ lookup('template', 'trex-app-cr.yaml.j2') }}"
+      vars:
+        packet_rate: 10kpps
+        packet_size: 64
 
-  - name: wait trex app run complete event
-    k8s_info:
-      namespace: "{{ cnf_namespace }}"
-      kind: Event
-      field_selectors:
-        - "reason==TestCompleted"
-        - "involvedObject.name={{ trex_app_cr_name }}"
-    register: trex_event
-    retries: 60
-    delay: 5
-    until: trex_event.resources|length > 0
+    - name: Wait for TRex app CR to be created
+      shell: |
+        {{ oc_tool_path }} get trexapp.examplecnf.openshift.io -o yaml -n {{ cnf_namespace }} {{ trex_app_cr_name }}
+      register: trex_app_cr_installation
+      retries: 30
+      delay: 10
+      until:
+        - "'True' in trex_app_cr_installation.stdout"
+        - "'Running' in trex_app_cr_installation.stdout"
+        - "'Successful' in trex_app_cr_installation.stdout"
 
-  - name: get test passed event from trex
-    k8s_info:
-      namespace: "{{ cnf_namespace }}"
-      kind: Event
-      field_selectors:
-        - "reason==TestPassed"
-        - "involvedObject.name={{ trex_app_cr_name }}"
-    register: trex_result
-    retries: 5
-    delay: 5
-    until: trex_result.resources | length > 0
+    - name: Wait for TRex app run start event
+      k8s_info:
+        namespace: "{{ cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==TestStarted"
+          - "involvedObject.name={{ trex_app_cr_name }}"
+      register: trex_event
+      retries: 60
+      delay: 5
+      until: trex_event.resources | length > 0
 
-  - name: get packet matched event from trex
-    k8s_info:
-      namespace: "{{ cnf_namespace }}"
-      kind: Event
-      field_selectors:
-        - "reason==PacketMatched"
-        - "involvedObject.name={{ trex_app_cr_name }}"
-    register: trex_result
-    retries: 60
-    delay: 5
-    until: "trex_result.resources|length > 0"
+    - name: Wait for TRex app TestCompleted event
+      k8s_info:
+        namespace: "{{ cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==TestCompleted"
+          - "involvedObject.name={{ trex_app_cr_name }}"
+      register: trex_event
+      retries: 60
+      delay: 5
+      until: trex_event.resources|length > 0
 
-  - name: set trex run status if passed
-    set_fact:
-      trex_app_run_passed: true
-    when: trex_result.resources|length > 0
+    - name: Get TestPassed event from TRex
+      k8s_info:
+        namespace: "{{ cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==TestPassed"
+          - "involvedObject.name={{ trex_app_cr_name }}"
+      register: trex_result
+      retries: 5
+      delay: 5
+      until: trex_result.resources | length > 0
+
+    - name: Get PacketMatched event from TRex
+      k8s_info:
+        namespace: "{{ cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==PacketMatched"
+          - "involvedObject.name={{ trex_app_cr_name }}"
+      register: trex_result
+      retries: 60
+      delay: 5
+      until: "trex_result.resources | length > 0"
+
+    - name: Set TRex run status if passed
+      set_fact:
+        trex_app_run_passed: true
+      when: trex_result.resources | length > 0
+  when: enable_trex_app | bool

--- a/roles/example-cnf-app/templates/trex-app-cr.yaml.j2
+++ b/roles/example-cnf-app/templates/trex-app-cr.yaml.j2
@@ -4,7 +4,7 @@ metadata:
   namespace: {{ cnf_namespace }}
   name: {{ trex_app_cr_name }}
   annotations:
-    "ansible.sdk.operatorframework.io/verbosity": "1"
+    "ansible.sdk.operatorframework.io/verbosity": "4"
     "ansible.sdk.operatorframework.io/reconcile-period": "1m"
 spec:
 {% if packet_rate|default('') %}

--- a/roles/example-cnf-app/templates/trex-server-cr.yaml.j2
+++ b/roles/example-cnf-app/templates/trex-server-cr.yaml.j2
@@ -4,7 +4,7 @@ metadata:
   namespace: {{ cnf_namespace }}
   name: {{ trex_cr_name }}
   annotations:
-    "ansible.sdk.operatorframework.io/verbosity": "0"
+    "ansible.sdk.operatorframework.io/verbosity": "4"
 spec:
 {% if trex_core_count|int > 0 %}
   environments:

--- a/roles/example-cnf-catalog/tasks/main.yml
+++ b/roles/example-cnf-catalog/tasks/main.yml
@@ -68,11 +68,16 @@
   until: pkg_manifest_trex.resources|length != 0
   failed_when: pkg_manifest_trex.resources|length == 0
 
-- name: create namespace
+- name: Create namespace
   k8s:
-    api_version: v1
-    name: "{{ cnf_namespace }}"
-    kind: Namespace
+    definition:
+      api_version: v1
+      kind: Namespace
+      metadata:
+        name: "{{ cnf_namespace }}"
+        labels:
+          pod-security.kubernetes.io/enforce: privileged
+          pod-security.kubernetes.io/enforce-version: latest
 
 - name: create operatorgroup
   k8s:

--- a/roles/example-cnf-destroy/tasks/machine-fix-sub.yaml
+++ b/roles/example-cnf-destroy/tasks/machine-fix-sub.yaml
@@ -19,7 +19,7 @@
   loop: "{{ nodes.resources }}"
 - name: delete machine if associated node is not found
   k8s:
-    api_version: machine.openshift.io/v1beta1
+    api_version: machine.openshift.io/v1
     name: "{{ machine_name }}"
     kind: Machine
     namespace: openshift-machine-api

--- a/roles/example-cnf-destroy/tasks/machine-fix.yaml
+++ b/roles/example-cnf-destroy/tasks/machine-fix.yaml
@@ -8,7 +8,7 @@
     msg: "Nodes = {{ nodes.resources|length }}"
 - name: get all machines
   k8s_info:
-    api_version: machine.openshift.io/v1beta1
+    api_version: machine.openshift.io/v1
     kind: Machine
     namespace: openshift-machine-api
   register: machines


### PR DESCRIPTION
[Initially, I was trying to fix this issue](https://www.distributed-ci.io/jobs/78fe7ced-e5fd-44c7-a81d-abf12540ed7e/jobStates?sort=date&task=13bad669-e93c-41fa-a4bf-08c28cf6740f), but it seems like the true fix is [to change events API in trex-app-container](https://github.com/rh-nfv-int/trex-container-app/pull/2).

I would prefer to merge this PR anyway because it makes the TRex installation to be more stable:
- Add security labels to example-cnf namespace
- Wait for TRex app CR to be created, and [here we see that it does take some time, like 20 seconds](https://www.distributed-ci.io/jobs/1d040f7a-1240-4f50-90fe-5581b7757cab/jobStates?sort=date&task=717000f4-80f7-430f-99df-7824b589ec38)
- Move from beta level v1beta1 to GA v1 for machine.openshift.io API

The change is tested green on OCP-4.7, OCP-4.10, and OCP-4.11.
On OCP-4.12, the error stays the same for the moment, it seems like we have to fix trex-app-container.