### PR TITLE
Use events API v1 for trex-operator during the deploy

### DIFF
--- a/quay-repo-v2.yaml
+++ b/quay-repo-v2.yaml
@@ -1,7 +1,7 @@
 ---
 cluster_name: ''
-operator_version: v0.2.4
-app_version: v0.2.2
+operator_version: v0.2.12
+app_version: v0.2.6
 registry_url: quay.io
 repo_name: rh-nfv-int
 


### PR DESCRIPTION
PR number 4.
This pull request is to use new [trex-operator image](https://github.com/rh-nfv-int/trex-operator/pull/9) and [new trex-container-app image](https://github.com/rh-nfv-int/trex-container-app/pull/2) during the deploy of example-cnf.

The change is tested on 4.7 - 4.13, here is the job for 4.12: https://www.distributed-ci.io/jobs/2b446378-c588-45e5-bf1d-902b407e2779/jobStates?sort=date
All the other links are in cilab-291.