### PR TITLE
adding a boolean to enable/disable the waiting of the end of tests

### DIFF
--- a/roles/example-cnf-app/defaults/main.yaml
+++ b/roles/example-cnf-app/defaults/main.yaml
@@ -10,6 +10,9 @@ enable_testpmd: true
 enable_trex: true
 enable_trex_app: true
 
+# If set to true, wait until the end of the profile duration before continue
+trex_tests_wait: true
+
 # Internal variables
 termination_grace_period_seconds: 30
 image_pull_policy: Always

--- a/roles/example-cnf-app/tasks/trex/tests.yaml
+++ b/roles/example-cnf-app/tasks/trex/tests.yaml
@@ -1,31 +1,35 @@
 ---
-- name: run additional tests
+- name: deploy TREX profiles
   include_tasks: trex/profile.yaml
   loop: "{{ trex_test_config }}"
   loop_control:
     loop_var: trex_test_config_item
-- name: get all trexapps
-  k8s_info:
-    namespace: "{{ cnf_namespace }}"
-    kind: TRexApp
-  register: trex_apps
-- name: set trex app count to default 0
-  set_fact:
-    trex_apps_count: 0
-- name: increment trex_app_count for apps with valid duration
-  set_fact:
-    trex_apps_count: "{{ trex_apps_count|int + 1 }}"
-  loop: "{{ trex_apps.resources }}"
-  when: "'duration' in item.spec and item.spec.duration != -1"
-- debug: var=trex_apps_count
-- name: wait trex app run complete event
-  k8s_info:
-    namespace: "{{ cnf_namespace }}"
-    kind: Event
-    field_selectors:
-      - "reason==TestCompleted"
-      - "involvedObject.kind=TRexApp"
-  register: evts
-  retries: "{{ trex_tests_retry_mins_count|default(60) }}"
-  delay: 60
-  until: "evts.resources|length >= trex_apps_count|int"
+- name: run additional tests
+  block:
+    - name: get all trexapps
+      k8s_info:
+        namespace: "{{ cnf_namespace }}"
+        kind: TRexApp
+      register: trex_apps
+    - name: set trex app count to default 0
+      set_fact:
+        trex_apps_count: 0
+    - name: increment trex_app_count for apps with valid duration
+      set_fact:
+        trex_apps_count: "{{ trex_apps_count|int + 1 }}"
+      loop: "{{ trex_apps.resources }}"
+      when: "'duration' in item.spec and item.spec.duration != -1"
+    - debug: var=trex_apps_count
+    - name: wait trex app run complete event
+      k8s_info:
+        namespace: "{{ cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==TestCompleted"
+          - "involvedObject.kind=TRexApp"
+      register: evts
+      retries: "{{ trex_tests_retry_mins_count|default(60) }}"
+      delay: 60
+      until: "evts.resources|length >= trex_apps_count|int"
+  when:
+   - trex_tests_wait | bool


### PR DESCRIPTION
When long duration TREX profile are defined, the playbook must wait until the end of all profiles before continue. which can be very long. This boolean disable this and trex/tests.yaml just deploys the profile and does not wait until the end of the test.