### PR TITLE
Disable Trex job retries to prevent race conditions

### DIFF
--- a/roles/example-cnf-app/tasks/retry-trex.yaml
+++ b/roles/example-cnf-app/tasks/retry-trex.yaml
@@ -1,9 +1,7 @@
 ---
 - name: Set retry variables
   set_fact:
-    trex_app_cr_name: trex-app1
-    trex_app_retry_count: "{{ trex_app_retry_count | default(0) | int + 1 }}"
-    trex_app_retry_max: "{{ trex_app_retry_max | default(5) | int }}"
+    trex_app_cr_name: trex-app
 
 - name: Deploy trex app (with retries)
   block:
@@ -15,13 +13,7 @@
         msg: "TRex App run has failed"
       when: not trex_app_run_passed | default(false) | bool
 
-  rescue:
-    - name: Fail when max retries have been reached ({{ trex_app_retry_count }}/{{ trex_app_retry_max }})
-      fail:
-        msg: "Maximum retries have been reached"
-      when:
-        - trex_app_retry_count | int == trex_app_retry_max | int
-
+  always:
     - name: Retrieve TRex app logs
       community.kubernetes.k8s_log:
         namespace: "{{ cnf_namespace }}"
@@ -34,7 +26,7 @@
     - name: Store logs when jobs_logs is defined
       copy:
         content: "{{ trex_app_logs.log }}"
-        dest: "{{ job_logs.path }}/{{ trex_app_cr_name }}-{{ trex_app_retry_count }}.log"
+        dest: "{{ job_logs.path }}/{{ trex_app_cr_name }}.log"
       when:
         - job_logs is defined
         - job_logs.path is defined
@@ -65,6 +57,4 @@
       retries: 30
       delay: 5
       until: "trex_result.resources|length == 0"
-
-    - name: Re-run TRex App to try again
-      include_tasks: retry-trex.yaml
+...

--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -86,31 +86,20 @@
       delay: 5
       until: trex_event.resources|length > 0
 
-    - name: Wait for the TRex app to produce TestPassed or TestFailed event
-      pause:
-        seconds: 30
-
-    - name: Fail if TestFailed event is present
+    - name: Wait for the TRex app TestPassed or TestFailed event
       k8s_info:
         namespace: "{{ cnf_namespace }}"
         kind: Event
-        field_selectors:
-          - "reason==TestFailed"
-          - "involvedObject.name={{ trex_app_cr_name }}"
-      register: trex_result
-      failed_when: trex_result.resources | length > 0
-
-    - name: Wait for the TRex app TestPassed event
-      k8s_info:
-        namespace: "{{ cnf_namespace }}"
-        kind: Event
-        field_selectors:
-          - "reason==TestPassed"
-          - "involvedObject.name={{ trex_app_cr_name }}"
+        field_selectors: "involvedObject.name={{ trex_app_cr_name }}"
       register: trex_result
       retries: 5
       delay: 5
-      until: trex_result.resources | length > 0
+      until: "trex_result.resources | selectattr('reason', 'in', ['TestPassed', 'TestFailed']) | list | length > 0"
+
+    - name: Fail if TestFailed event is present
+      fail:
+        msg: "TestFailed event detected"
+      when: "'TestFailed' in trex_result.resources | map(attribute='reason') | list"
 
     - name: Wait for the TRex app PacketMatched event
       k8s_info:

--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -62,7 +62,7 @@
         - "'Running' in trex_app_cr_installation.stdout"
         - "'Successful' in trex_app_cr_installation.stdout"
 
-    - name: Wait for TRex app run start event
+    - name: Wait for the TRex app TestStarted event
       k8s_info:
         namespace: "{{ cnf_namespace }}"
         kind: Event
@@ -74,7 +74,7 @@
       delay: 5
       until: trex_event.resources | length > 0
 
-    - name: Wait for TRex app TestCompleted event
+    - name: Wait for the TRex app TestCompleted event
       k8s_info:
         namespace: "{{ cnf_namespace }}"
         kind: Event
@@ -86,7 +86,21 @@
       delay: 5
       until: trex_event.resources|length > 0
 
-    - name: Get TestPassed event from TRex
+    - name: Wait for the TRex app to produce TestPassed or TestFailed event
+      pause:
+        seconds: 30
+
+    - name: Fail if TestFailed event is present
+      k8s_info:
+        namespace: "{{ cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - "reason==TestFailed"
+          - "involvedObject.name={{ trex_app_cr_name }}"
+      register: trex_result
+      failed_when: trex_result.resources | length > 0
+
+    - name: Wait for the TRex app TestPassed event
       k8s_info:
         namespace: "{{ cnf_namespace }}"
         kind: Event
@@ -98,7 +112,7 @@
       delay: 5
       until: trex_result.resources | length > 0
 
-    - name: Get PacketMatched event from TRex
+    - name: Wait for the TRex app PacketMatched event
       k8s_info:
         namespace: "{{ cnf_namespace }}"
         kind: Event
@@ -115,3 +129,4 @@
         trex_app_run_passed: true
       when: trex_result.resources | length > 0
   when: enable_trex_app | bool
+...


### PR DESCRIPTION
In the [daily logs](https://www.distributed-ci.io/jobs/e3690773-551a-45dc-a5ac-af6393a7bda3/jobStates?sort=date), we can observe race conditions occurring between several TRex jobs running in parallel: 

```
2023_09_04_job_logs]$ grep -a trexapp example-cnf_events.log 
3m59s       Normal    TestStarted            trexapp/trex-app1                                                         Started streams with profile (default) at rate (10kpps) for (120)s
41s         Normal    TestStarted            trexapp/trex-app1                                                         Started streams with profile (default) at rate (10kpps) for (120)s
9m49s       Normal    TestStarted            trexapp/trex-app1                                                         Started streams with profile (default) at rate (10kpps) for (120)s
7m24s       Normal    TestCompleted          trexapp/trex-app1                                                         Profile (default) with size (64) with rate (10kpps) for (120)s have completed
5m38s       Normal    TestStarted            trexapp/trex-app1                                                         Started streams with profile (default) at rate (10kpps) for (120)s
2m21s       Normal    TestStarted            trexapp/trex-app1                                                         Started streams with profile (default) at rate (10kpps) for (120)s
7m24s       Normal    TestFailed             trexapp/trex-app1                                                         Test has failed with packets loss of 263181 pkts
```
We have 5 TestStarted events, one TestCompleted and one TestFailed. That means, that only the first test was completed.

We then rerun the test 4 more times. However, every time it considers the test as done because of that event TestCompleted from the first test in the namespace. That means rerunning the test as it is now causes these competing situations. 

To avoid this, we should clean things up by deleting the namespace and reinstalling all the operators. For the moment, I simply deactivated job retries causing race conditions, and will be concentrating on fixing the job itself.