### PR TITLE
Remove testpmd_image reference

### DIFF
--- a/roles/example-cnf-app/defaults/main.yaml
+++ b/roles/example-cnf-app/defaults/main.yaml
@@ -17,10 +17,6 @@ termination_grace_period_seconds: 30
 image_pull_policy: Always
 catalog_name: nfv-example-cnf-catalog
 catalog_image: "{{ registry_url }}/{{ repo_name }}/{{ catalog_name }}:{{ operator_version }}"
-# To guarantee support to disconnected environments, this image must be the
-# same as the one used by the testpmd-operator and must use its digest.
-# https://github.com/rh-nfv-int/testpmd-operator/blob/master/relatedImages.yaml#L3
-image_testpmd: "registry.redhat.io/openshift4/dpdk-base-rhel8@sha256:9af03fb4c5ae1c51f71ad04f02fee8e9458aa73c3f4324e984c731d07896c4e1"  # v4.6.3
 
 cnf_namespace: example-cnf
 trex_cr_name: trexconfig

--- a/roles/example-cnf-app/templates/testpmd-cr.yaml.j2
+++ b/roles/example-cnf-app/templates/testpmd-cr.yaml.j2
@@ -4,7 +4,6 @@ metadata:
   name: testpmd
   namespace: {{ cnf_namespace }}
 spec:
-  image_testpmd: {{ image_testpmd }}
   privileged: false
   imagePullPolicy: {{ image_pull_policy }}
 {% if enable_lb|bool %}


### PR DESCRIPTION
The provision of this image is now provided and automated in [example-cnf](https://github.com/openshift-kni/example-cnf) repository. Due to this current code, all the updates made on example-cnf for testpmd-operator / testpmd-app image are not being taken into consideration because they're overriden by this hardcoded image.