### PR TITLE
Remove MAC workaround

### DIFF
--- a/roles/example-cnf-app/tasks/app.yaml
+++ b/roles/example-cnf-app/tasks/app.yaml
@@ -27,13 +27,6 @@
     ocp_major: "{{ cluster_version.resources[0].spec.channel.split('-')[1].split('.')[0] }}"
     ocp_minor: "{{ cluster_version.resources[0].spec.channel.split('-')[1].split('.')[1] }}"
 
-- name: Set mac workaround
-  set_fact:
-    mac_workaround_enable: true
-  when:
-    - ocp_major|int == 4
-    - ocp_minor|int <= 5
-
 - name: get all nodes
   k8s_info:
     kind: Node

--- a/roles/example-cnf-app/templates/testpmd-cr.yaml.j2
+++ b/roles/example-cnf-app/templates/testpmd-cr.yaml.j2
@@ -18,10 +18,6 @@ spec:
 {% if high_perf_runtime is defined and high_perf_runtime|length %}
   runtimeClassName: "{{ high_perf_runtime }}"
 {% endif %}
-{% if mac_workaround_enable|default(false)|bool %}
-  macWorkaroundEnable: true
-  macWorkaroundVersion: "{% if 'v0.0.' in operator_version %}4.4{% else %}{{ ocp_version }}{% endif %}"
-{% endif %}
 {% if numa_aware_topology is defined and numa_aware_topology | length %}
   numa_aware_topology: "{{ numa_aware_topology }}"
 {% endif %}


### PR DESCRIPTION
This is no longer used since it was just required for OCP 4.5, which is EOL.