### PR TITLE
Configure trex job duration time

### DIFF
--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -42,7 +42,7 @@
   block:
     - name: Set TRex app duration
       set_fact:
-        duration: "{{ trex_duration | default(120) }}"
+        duration: "{{ trex_duration|int | default(120) }}"
 
     - name: Create CR for TRex app
       k8s:

--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -42,7 +42,7 @@
   block:
     - name: Set TRex app duration
       set_fact:
-        duration: "{{ trex_duration|int | default(120) }}"
+        duration: "{{ trex_duration | default(120) }}"
 
     - name: Create CR for TRex app
       k8s:
@@ -70,7 +70,7 @@
           - "reason==TestStarted"
           - "involvedObject.name={{ trex_app_cr_name }}"
       register: trex_event
-      retries: "{{ (duration/2)|round|int }}"
+      retries: "{{ (duration|int/2)|round|int }}"
       delay: 5
       until: trex_event.resources | length > 0
 
@@ -82,7 +82,7 @@
           - "reason==TestCompleted"
           - "involvedObject.name={{ trex_app_cr_name }}"
       register: trex_event
-      retries: "{{ (duration/2)|round|int }}"
+      retries: "{{ (duration|int/2)|round|int }}"
       delay: 5
       until: trex_event.resources|length > 0
 
@@ -109,7 +109,7 @@
           - "reason==PacketMatched"
           - "involvedObject.name={{ trex_app_cr_name }}"
       register: trex_result
-      retries: "{{ (duration/2)|round|int }}"
+      retries: "{{ (duration|int/2)|round|int }}"
       delay: 5
       until: "trex_result.resources | length > 0"
 

--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -40,9 +40,9 @@
 
 - name: TRexApp block
   block:
-    - name: Set TRex app CR name
+    - name: Set TRex app duration
       set_fact:
-        duration: 120
+        duration: "{{ trex_duration | default(120) }}"
 
     - name: Create CR for TRex app
       k8s:
@@ -70,7 +70,7 @@
           - "reason==TestStarted"
           - "involvedObject.name={{ trex_app_cr_name }}"
       register: trex_event
-      retries: 60
+      retries: "{{ (duration/2)|round|int }}"
       delay: 5
       until: trex_event.resources | length > 0
 
@@ -82,7 +82,7 @@
           - "reason==TestCompleted"
           - "involvedObject.name={{ trex_app_cr_name }}"
       register: trex_event
-      retries: 60
+      retries: "{{ (duration/2)|round|int }}"
       delay: 5
       until: trex_event.resources|length > 0
 
@@ -109,7 +109,7 @@
           - "reason==PacketMatched"
           - "involvedObject.name={{ trex_app_cr_name }}"
       register: trex_result
-      retries: 60
+      retries: "{{ (duration/2)|round|int }}"
       delay: 5
       until: "trex_result.resources | length > 0"
 


### PR DESCRIPTION
By defining an external variable called trex_duration, just allow setting up the duration of trex run, as well as the checks we're doing to confirm it's working.