### PR TITLE
Use opm binary downloaded from dci-openshift-app-agent

### DIFF
--- a/roles/example-cnf-app/tasks/main.yaml
+++ b/roles/example-cnf-app/tasks/main.yaml
@@ -8,7 +8,7 @@
   ansible.builtin.shell:
     cmd: >
       set -e -o pipefail;
-      ~/clusterconfigs-{{ cluster_name }}/opm render
+      {{ opm_tool_path }} render
       {{ catalog_image }} |
       jq -r '.relatedImages[].image'
   args:


### PR DESCRIPTION
This is to avoid the issue with opm binary found yesterday and that is causing CILAB-1108 today in daily jobs. We should use the opm binary that is downloaded by dci-openshift-app-agent