### PR TITLE
Link some tasks to enable_lb flag

### DIFF
--- a/roles/example-cnf-app/tasks/app.yaml
+++ b/roles/example-cnf-app/tasks/app.yaml
@@ -60,6 +60,7 @@
   set_fact:
     pack_nw: []
     cnf_nw: []
+  when: enable_lb|bool
 
 - name: create packet gen network list for lb with hardcoded macs
   set_fact:
@@ -67,6 +68,7 @@
   loop: "{{ packet_generator_networks }}"
   loop_control:
     index_var: idx
+  when: enable_lb|bool
 
 - name: create cnf app network list for lb with hardcoded macs
   set_fact:
@@ -74,6 +76,7 @@
   loop: "{{ cnf_app_networks }}"
   loop_control:
     index_var: idx
+  when: enable_lb|bool
 
 - name: include lb tasks
   include_tasks: lb-app.yaml


### PR DESCRIPTION
`pack_nw` and `cnf_nw` are only used for the LoadBalancer CR, it should not be used when using example-cnf in direct-mode