### PR TITLE
Removing the check that makes the job to fail if multiple network resources are used

### DIFF
--- a/cluster-specific-params.yaml
+++ b/cluster-specific-params.yaml
@@ -1,9 +1,12 @@
 ---
 cnf_app_networks:
   - name: intel-numa0-net1
-    count: 2
+    count: 1
+  - name: intel-numa0-net2
+    count: 1
 
 packet_generator_networks:
-  - name: intel-numa0-net2
-    count: 2
-
+  - name: intel-numa0-net3
+    count: 1
+  - name: intel-numa0-net4
+    count: 1

--- a/roles/example-cnf-app/tasks/app.yaml
+++ b/roles/example-cnf-app/tasks/app.yaml
@@ -51,10 +51,10 @@
   when:
     - "cnf_app_networks|length == 0"
 
-- name: Fail when both cnf app and packet generator networks are defined
-  fail:
-    msg: "MAC merging is not supported with multiple networks"
-  when: "cnf_app_networks|length > 1 or (enable_lb|bool and packet_generator_networks|length > 1)"
+#- name: Fail when both cnf app and packet generator networks are defined
+#  fail:
+#    msg: "MAC merging is not supported with multiple networks"
+#  when: "cnf_app_networks|length > 1 or (enable_lb|bool and packet_generator_networks|length > 1)"
 
 - name: set facts of modifying networks
   set_fact:

--- a/roles/example-cnf-app/tasks/app.yaml
+++ b/roles/example-cnf-app/tasks/app.yaml
@@ -51,11 +51,6 @@
   when:
     - "cnf_app_networks|length == 0"
 
-#- name: Fail when both cnf app and packet generator networks are defined
-#  fail:
-#    msg: "MAC merging is not supported with multiple networks"
-#  when: "cnf_app_networks|length > 1 or (enable_lb|bool and packet_generator_networks|length > 1)"
-
 - name: set facts of modifying networks
   set_fact:
     pack_nw: []

--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -5,12 +5,6 @@
     packet_gen_net: "{{ packet_generator_networks if enable_lb|bool else cnf_app_networks }}"
     trex_app_run_passed: false
 
-# TODO(skramaja): This logic to be improved for multiple
-# networks, lets fail it if the length is > 1
-- fail:
-    msg: "Need to rewrite the mac merging logic"
-  when: "packet_gen_net|length != 1"
-
 - name: Create network list for trex with hardcoded macs
   set_fact:
     networks_trex: "{{ networks_trex + [ item | combine({ 'mac': trex_mac_list[idx:idx+item.count] }) ] }}"


### PR DESCRIPTION
- logic added in example-cnf to allow that, so this check is no longer needed - https://github.com/openshift-kni/example-cnf/pull/62
- also, change cluster-specific-params to reflect the scenario with 4 SRIOV nets