### PR TITLE
Always wait for containers to be ready

### DIFF
--- a/roles/example-cnf-app/tasks/app.yaml
+++ b/roles/example-cnf-app/tasks/app.yaml
@@ -81,7 +81,7 @@
   k8s:
     definition: "{{ lookup('template', 'testpmd-cr.yaml.j2') }}"
 
-- name: check testpmd pod count to be greater than 1
+- name: check testpmd pod count to be greater than 0
   k8s_info:
     namespace: "{{ cnf_namespace }}"
     kind: Pod
@@ -91,8 +91,9 @@
   retries: 60
   delay: 5
   until:
-    - testpmd_pods.resources|length >= 1
+    - testpmd_pods.resources|length > 0
 
+# At least confirm that the first testpmd pod is up and running
 - name: check testpmd pod status to be running
   k8s_info:
     namespace: "{{ cnf_namespace }}"
@@ -100,21 +101,49 @@
     label_selectors:
       - example-cnf-type=cnf-app
   register: testpmd_pods
+  vars:
+    container_state_running_query: "resources[0].status.containerStatuses[?name=='testpmd'].state.running"
+    container_started_query: "resources[0].status.containerStatuses[?name=='testpmd'].started"
+    container_ready_query: "resources[0].status.containerStatuses[?name=='testpmd'].ready"
+    container_state_running: "{{ testpmd_pods | json_query(container_state_running_query) }}"
+    container_started: "{{ testpmd_pods | json_query(container_started_query) }}"
+    container_ready: "{{ testpmd_pods | json_query(container_ready_query) }}"
   retries: 60
   delay: 5
   until:
     - testpmd_pods.resources[0].status.phase == 'Running'
+    - container_state_running | length > 0
+    - container_started | length > 0
+    - container_started[0] | bool
+    - container_ready | length > 0
+    - container_ready[0] | bool
 
-- name: check cnfappmac resource (created by testpmd app)
+- name: check cnfappmac resource (created by testpmd app) count to be greater than 0
   k8s_info:
     namespace: "{{ cnf_namespace }}"
     kind: CNFAppMac
-  register: mac
+  register: cnfappmac
   retries: 120
   delay: 5
   until:
-    - mac.resources is defined
-    - mac.resources|length > 0
+    - cnfappmac.resources is defined
+    - cnfappmac.resources|length > 0
+
+# CNFAppMac and testpmd pods share the same name, so we can use it for doing
+# some extra checks
+- name: check that at least the cnfappmac resource for the first testpmd pod has the required data
+  k8s_info:
+    namespace: "{{ cnf_namespace }}"
+    kind: CNFAppMac
+    name: "{{ testpmd_pods.resources[0].metadata.name }}"
+  register: first_cnfappmac
+  retries: 120
+  delay: 5
+  until:
+    - first_cnfappmac.resources is defined
+    - first_cnfappmac.resources|length > 0
+    - first_cnfappmac.resources[0].spec.resources is defined
+    - first_cnfappmac.resources[0].spec.resources|length > 0
 
 - name: trex cr block
   include_tasks: retry-trex.yaml

--- a/roles/example-cnf-app/tasks/lb-app.yaml
+++ b/roles/example-cnf-app/tasks/lb-app.yaml
@@ -11,11 +11,19 @@
       - example-cnf-type=lb-app
   register: lb_pods
   vars:
-    container_query: "resources[0].status.containerStatuses[?name=='loadbalancer'].state.running"
-    container_status: "{{ lb_pods | json_query(container_query) }}"
+    container_state_running_query: "resources[0].status.containerStatuses[?name=='loadbalancer'].state.running"
+    container_started_query: "resources[0].status.containerStatuses[?name=='loadbalancer'].started"
+    container_ready_query: "resources[0].status.containerStatuses[?name=='loadbalancer'].ready"
+    container_state_running: "{{ lb_pods | json_query(container_state_running_query) }}"
+    container_started: "{{ lb_pods | json_query(container_started_query) }}"
+    container_ready: "{{ lb_pods | json_query(container_ready_query) }}"
   retries: 60
   delay: 5
   until:
     - lb_pods.resources | length == 1
     - lb_pods.resources[0].status.phase == 'Running'
-    - container_status | length > 0
+    - container_state_running | length > 0
+    - container_started | length > 0
+    - container_started[0] | bool
+    - container_ready | length > 0
+    - container_ready[0] | bool

--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -23,9 +23,23 @@
     label_selectors:
       - example-cnf-type=pkt-gen
   register: trex_result
-  until: trex_result | json_query('resources[*].status.phase') | unique == ["Running"]
+  vars:
+    container_state_running_query: "resources[0].status.containerStatuses[?name=='trex-server'].state.running"
+    container_started_query: "resources[0].status.containerStatuses[?name=='trex-server'].started"
+    container_ready_query: "resources[0].status.containerStatuses[?name=='trex-server'].ready"
+    container_state_running: "{{ trex_result | json_query(container_state_running_query) }}"
+    container_started: "{{ trex_result | json_query(container_started_query) }}"
+    container_ready: "{{ trex_result | json_query(container_ready_query) }}"
   retries: 60
   delay: 5
+  until:
+    - trex_result.resources | length == 1
+    - trex_result.resources[0].status.phase == 'Running'
+    - container_state_running | length > 0
+    - container_started | length > 0
+    - container_started[0] | bool
+    - container_ready | length > 0
+    - container_ready[0] | bool
 
 - name: Set TRex run status if the previous step passed
   set_fact:


### PR DESCRIPTION
Sometimes, we move to next steps in the example-cnf deployment, but in fact, the containers we're deploying are not still ready.
This change is just to make sure all the pieces from the pods under test are ready to move forward on each stage of the deployment.