### PR TITLE
Wait 2 minutes before starting TRex test

### DIFF
--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -46,6 +46,10 @@
     trex_app_run_passed: true
   when: trex_result.resources | length > 0
 
+- name: Wait 2 minutes to have all resources ready for the TRex app test
+  pause:
+    seconds: 120
+
 - name: TRexApp block
   block:
     - name: Set TRex app duration


### PR DESCRIPTION
In today's daily jobs with the full SRIOV network setup, we have cases where the test passed:

- https://www.distributed-ci.io/jobs/bd99770b-4104-429c-a8c6-a16d0963eb41/jobStates (direct mode, cluster3)
- https://www.distributed-ci.io/jobs/b307a428-4b58-4495-bf6f-27151cc2c68e/jobStates (LB mode, cluster1)

And others where it failed

- https://www.distributed-ci.io/jobs/b5606e45-cf35-4d21-8920-8f1a8f0496f1/jobStates (direct mode, cluster1)

It looks like the issue is not related to the cluster, since it worked in the same cluster in one attempt today and failed in the other one.

In fact, the job that failed doesn't have 100% packet loss like in other executions, it has 99%, so it makes me think that, maybe, we need to wait more time for pods in the scenario.

Adding 2 minutes to wait before starting TRex test. Maybe there are smarter ways of doing this, but we're doing the same in other partner hooks, and probably this can mitigate the issues we're having