### PR TITLE
Debug feature - avoid to fail the job if trex_tests_skip_failures is set

### DIFF
--- a/roles/example-cnf-app/defaults/main.yaml
+++ b/roles/example-cnf-app/defaults/main.yaml
@@ -9,6 +9,9 @@ enable_testpmd: true
 enable_trex: true
 enable_trex_app: true
 
+# If set to true, even if TRex job fails, the job will progress
+trex_tests_skip_failures: false
+
 # If set to true, wait until the end of the profile duration before continue
 trex_tests_wait: true
 

--- a/roles/example-cnf-app/tasks/retry-trex.yaml
+++ b/roles/example-cnf-app/tasks/retry-trex.yaml
@@ -11,7 +11,9 @@
     - name: Fail when run did not pass
       fail:
         msg: "TRex App run has failed"
-      when: not trex_app_run_passed | default(false) | bool
+      when:
+        - not trex_app_run_passed | default(false) | bool
+        - not trex_tests_skip_failures|bool
   always:
     - name: Retrieve TRex app logs
       community.kubernetes.k8s_log:

--- a/roles/example-cnf-app/tasks/trex/app.yaml
+++ b/roles/example-cnf-app/tasks/trex/app.yaml
@@ -133,7 +133,9 @@
     - name: Fail if TestFailed event is present
       fail:
         msg: "TestFailed event detected"
-      when: "'TestFailed' in trex_result.resources | map(attribute='reason') | list"
+      when:
+        - "'TestFailed' in trex_result.resources | map(attribute='reason') | list"
+        - not trex_tests_skip_failures|bool
 
     - name: Wait for the TRex app PacketMatched event
       k8s_info:
@@ -146,10 +148,15 @@
       retries: "{{ (duration|int/2)|round|int }}"
       delay: 5
       until: "trex_result.resources | length > 0"
+      when:
+        - not trex_tests_skip_failures|bool
 
     - name: Set TRex run status if passed
       set_fact:
         trex_app_run_passed: true
-      when: trex_result.resources | length > 0
+      when:
+        - trex_result is defined
+        - trex_result.resources is defined
+        - trex_result.resources | length > 0
   when: enable_trex_app | bool
 ...

--- a/roles/example-cnf-validate/defaults/main.yml
+++ b/roles/example-cnf-validate/defaults/main.yml
@@ -4,3 +4,9 @@ cnf_namespace: example-cnf
 
 oc_tool_path: oc
 kubeconfig_path: ''
+
+# If set to true, even if TRex job fails, the job will progress
+trex_tests_skip_failures: false
+
+# The idea is always to try to run the migration test, unless TRex job failed before
+try_running_migration_tests: true

--- a/roles/example-cnf-validate/tasks/main.yml
+++ b/roles/example-cnf-validate/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - include_tasks: migrate.yml
 - include_tasks: validate.yml
+  when: try_running_migration_tests|bool

--- a/roles/example-cnf-validate/tasks/migrate.yml
+++ b/roles/example-cnf-validate/tasks/migrate.yml
@@ -9,36 +9,58 @@
     msg: "TestPMD CRs count ({{ testpmd_list.resources|length }}) is invalid "
   when: "testpmd_list.resources|length != 1"
 
-- name: Wait for at least one PacketMatched event from TRex
+# This means that the TRex job may have failed, so we don't want to run the migration
+# tests in that case
+- name: Check if previous TRex job worked when trex_tests_skip_failures is activated
   k8s_info:
     namespace: "{{ cnf_namespace }}"
     kind: Event
     field_selectors:
       - reason==PacketMatched
   register: matched
-  retries: 12
-  delay: 5
-  until: matched.resources | length > 0
+  when: trex_tests_skip_failures|bool
 
-- name: kubeconfig path if not available
-  when: "kubeconfig_path|default('')|length == 0"
+- name: Do not try migration tests if previous TRex job failed
+  set_fact:
+    try_running_migration_tests: false
+  when:
+    - trex_tests_skip_failures|bool
+    - matched.resources is defined
+    - matched.resources|length == 0
+
+- name: Try to run migration tests
+  when: try_running_migration_tests|bool
   block:
-  - name: get kubeconfig path of not provided
-    shell: "echo $KUBECONFIG"
-    register: kc_out
-  - name: fail if KUBECONFIG env is not found and kubeconfig_path is not set
-    fail:
-      msg: "Failed to find kubeconfig"
-    when: kc_out.stdout|length == 0
-  - name: set kubeconfig path
-    set_fact:
-      kubeconfig_path: "{{ kc_out.stdout }}"
+    - name: Wait for at least one PacketMatched event from TRex
+      k8s_info:
+        namespace: "{{ cnf_namespace }}"
+        kind: Event
+        field_selectors:
+          - reason==PacketMatched
+      register: matched
+      retries: 12
+      delay: 5
+      until: matched.resources | length > 0
 
-- name: run pod deletion test
-  include_tasks: pod-delete.yaml
-  when: "validate_pod_delete|default(true)|bool"
+    - name: kubeconfig path if not available
+      when: "kubeconfig_path|default('')|length == 0"
+      block:
+      - name: get kubeconfig path of not provided
+        shell: "echo $KUBECONFIG"
+        register: kc_out
+      - name: fail if KUBECONFIG env is not found and kubeconfig_path is not set
+        fail:
+          msg: "Failed to find kubeconfig"
+        when: kc_out.stdout|length == 0
+      - name: set kubeconfig path
+        set_fact:
+          kubeconfig_path: "{{ kc_out.stdout }}"
 
-# NOTE: Pod will not be migrated when node is rebooted, --pod-eviction-timeout is 5m default
-#- name: run node reboot test
-#  include_tasks: node-reboot.yaml
-#  when: "validate_node_reboot|default(true)|bool"
+    - name: run pod deletion test
+      include_tasks: pod-delete.yaml
+      when: "validate_pod_delete|default(true)|bool"
+
+    # NOTE: Pod will not be migrated when node is rebooted, --pod-eviction-timeout is 5m default
+    #- name: run node reboot test
+    #  include_tasks: node-reboot.yaml
+    #  when: "validate_node_reboot|default(true)|bool"


### PR DESCRIPTION
Sometimes we want to test some example-cnf configs after its deployment (e.g. tnf tests) but, if the test fails, we cannot really test it.
This is just to have a way of progressing in the job in case we need it.
This affects to example-cnf-app and example-cnf-validation, since we don't want to run migration tests if the TRex job failed previously (so no PacketMatched events will be present).