### PR TITLE
Hardcode MAC addresses for testpmd-app

### DIFF
--- a/roles/example-cnf-app/defaults/main.yaml
+++ b/roles/example-cnf-app/defaults/main.yaml
@@ -33,6 +33,9 @@ lb_gen_port_mac_list:
 lb_cnf_port_mac_list:
   - "60:04:0f:f1:89:01"
   - "60:04:0f:f1:89:02"
+testpmd_app_mac_list:
+  - "80:04:0f:f1:89:01"
+  - "80:04:0f:f1:89:02"
 cnf_app_networks: []
 
 # RuntimeClass that should be used for running DPDK application,

--- a/roles/example-cnf-app/tasks/app.yaml
+++ b/roles/example-cnf-app/tasks/app.yaml
@@ -77,6 +77,17 @@
   include_tasks: lb-app.yaml
   when: enable_lb|bool
 
+- name: Set local fact for cnf-app pod networks
+  set_fact:
+    networks_testpmd_app: []
+
+- name: Create network list for cnfapp with hardcoded macs
+  set_fact:
+    networks_testpmd_app: "{{ networks_testpmd_app + [ item | combine({ 'mac': testpmd_app_mac_list[idx:idx+item.count] }) ] }}"
+  loop: "{{ cnf_app_networks }}"
+  loop_control:
+    index_var: idx
+
 - name: create cr for cnf application
   k8s:
     definition: "{{ lookup('template', 'testpmd-cr.yaml.j2') }}"

--- a/roles/example-cnf-app/templates/testpmd-cr.yaml.j2
+++ b/roles/example-cnf-app/templates/testpmd-cr.yaml.j2
@@ -13,7 +13,7 @@ spec:
   ethpeerMaclist: {{ trex_mac_list }}
   size: 1  
 {% endif %}
-  networks: {{ cnf_app_networks }}
+  networks: {{ networks_testpmd_app }}
   terminationGracePeriodSeconds: {{ termination_grace_period_seconds }}
 {% if high_perf_runtime is defined and high_perf_runtime|length %}
   runtimeClassName: "{{ high_perf_runtime }}"


### PR DESCRIPTION
To emulate the node draining process while trex job is still running, the new testpmd pod needs to have the same MAC address than the first one, so using hardcoded MAC addresses to ensure this as a first attempt