### PR TITLE
Do not use hardcoded MAC addresses for testpmd in LB mode

### DIFF
--- a/roles/example-cnf-app/defaults/main.yaml
+++ b/roles/example-cnf-app/defaults/main.yaml
@@ -35,6 +35,7 @@ catalog_image: "{{ registry_url }}/{{ repo_name }}/{{ catalog_name }}:{{ operato
 cnf_namespace: example-cnf
 trex_cr_name: trexconfig
 
+# Static MAC addresses used by the deployed workloads
 trex_mac_list:
   - "20:04:0f:f1:89:01"
   - "20:04:0f:f1:89:02"
@@ -44,16 +45,23 @@ lb_gen_port_mac_list:
 lb_cnf_port_mac_list:
   - "60:04:0f:f1:89:01"
   - "60:04:0f:f1:89:02"
+## These ones are only used in the direct mode case
 testpmd_app_mac_list:
   - "80:04:0f:f1:89:01"
   - "80:04:0f:f1:89:02"
+
+# Variables for gathering the network info from the scenario
+## Connection between LB-CNF in LB mode (or TRex-CNF in direct mode)
 cnf_app_networks: []
+## Connection between TRex-LB in LB mode (not used in direct mode)
+packet_generator_networks: []
+## Networks for the CNF, including the hardcoded MAC addresses for direct mode case
+networks_testpmd_app: []
 
 # RuntimeClass that should be used for running DPDK application,
 # if the var is empty, the annotation irq-load-balancing.crio.io: "disable" is not applied
 # high_perf_runtime: "performance-blueprint-profile"
 
-packet_generator_networks: []
 
 packet_rate: 10kpps
 # some nics like x540 supports only 2 queues, as number of cores will be

--- a/roles/example-cnf-app/tasks/app.yaml
+++ b/roles/example-cnf-app/tasks/app.yaml
@@ -77,16 +77,20 @@
   include_tasks: lb-app.yaml
   when: enable_lb|bool
 
-- name: Set local fact for cnf-app pod networks
+# In this case, do not include hardcoded MAC addresses
+- name: (LB mode) Set local fact for cnf-app pod networks
   set_fact:
-    networks_testpmd_app: []
+    networks_testpmd_app: "{{ cnf_app_networks }}"
+  when: enable_lb|bool
 
-- name: Create network list for cnfapp with hardcoded macs
+# In this case, include hardcoded MAC addresses
+- name: (Direct mode) Create network list for cnfapp with hardcoded macs
   set_fact:
     networks_testpmd_app: "{{ networks_testpmd_app + [ item | combine({ 'mac': testpmd_app_mac_list[idx:idx+item.count] }) ] }}"
   loop: "{{ cnf_app_networks }}"
   loop_control:
     index_var: idx
+  when: not enable_lb|bool
 
 - name: create cr for cnf application
   k8s:


### PR DESCRIPTION
After https://github.com/rh-nfv-int/nfv-example-cnf-deploy/pull/59, we're always hardcoding the MAC addresses in the testpmd pods. However, the LB performs the load balancing based on the destination MAC address, so right now we're duplicating the traffic generated by TRex instead of "balancing" it between the two testpmd pods, acheving -100% packet loss (because the traffic is duplicated).

With this change, we just ensure that the MAC addresses are just hardcoded in the direct mode, where we only have one testpmd pod. We need to do this for the draining, to ensure the same MAC is used when recreating the pod. However, for the LB case, where we're not testing the draining, we can use again random MAC addresses